### PR TITLE
Fix compiler warnings.

### DIFF
--- a/src/brpc/builtin/prometheus_metrics_service.cpp
+++ b/src/brpc/builtin/prometheus_metrics_service.cpp
@@ -198,7 +198,7 @@ bool PrometheusMetricsDumper::DumpStatusJsonString(
         name + std::string("{");
 
     // 遍历json并打印
-    int count = 0;
+    butil::rapidjson::SizeType count = 0;
     BUTIL_RAPIDJSON_NAMESPACE::Value::MemberIterator it = d.MemberBegin();
     while (it != d.MemberEnd()) {
         count++;

--- a/src/brpc/policy/rtmp_protocol.cpp
+++ b/src/brpc/policy/rtmp_protocol.cpp
@@ -732,7 +732,8 @@ RtmpContext::RtmpContext(const RtmpClientOptions* copt, const Server* server)
     _free_ms_ids.reserve(32);
     CHECK_EQ(0, _mstream_map.init(1024, 70));
     CHECK_EQ(0, _trans_map.init(1024, 70));
-    memset(_cstream_ctx, 0, sizeof(_cstream_ctx));
+    for (size_t i = 0; i < ARRAY_SIZE(_cstream_ctx); ++i)
+        _cstream_ctx[i].store(0, butil::memory_order_relaxed);
 }
     
 RtmpContext::~RtmpContext() {
@@ -808,7 +809,8 @@ RtmpUnsentMessage::AppendAndDestroySelf(butil::IOBuf* out, Socket* s) {
 }
 
 RtmpContext::SubChunkArray::SubChunkArray() {
-    memset(ptrs, 0, sizeof(ptrs));
+    for (size_t i = 0; i < ARRAY_SIZE(ptrs); ++i)
+        ptrs[i].store(0, butil::memory_order_relaxed);
 }
 
 RtmpContext::SubChunkArray::~SubChunkArray() {

--- a/src/bthread/fd.cpp
+++ b/src/bthread/fd.cpp
@@ -46,7 +46,8 @@ class LazyArray {
 
 public:
     LazyArray() {
-        memset(_blocks, 0, sizeof(butil::atomic<Block*>) * NBLOCK);
+        for (size_t i = 0; i < NBLOCK; ++i)
+            _blocks[i].store(0, butil::memory_order_relaxed);
     }
 
     butil::atomic<T>* get_or_new(size_t index) {

--- a/src/bthread/fd.cpp
+++ b/src/bthread/fd.cpp
@@ -47,7 +47,7 @@ class LazyArray {
 public:
     LazyArray() {
         for (size_t i = 0; i < NBLOCK; ++i)
-            _blocks[i].store(0, butil::memory_order_relaxed);
+            _blocks[i].store(NULL, butil::memory_order_relaxed);
     }
 
     butil::atomic<T>* get_or_new(size_t index) {

--- a/src/butil/object_pool_inl.h
+++ b/src/butil/object_pool_inl.h
@@ -111,7 +111,9 @@ public:
             // We fetch_add nblock in add_block() before setting the entry,
             // thus address_resource() may sees the unset entry. Initialize
             // all entries to NULL makes such address_resource() return NULL.
-            memset(blocks, 0, sizeof(butil::atomic<Block*>) * OP_GROUP_NBLOCK);
+            for (size_t i = 0; i < OP_GROUP_NBLOCK; ++i) {
+                blocks[i].store(NULL, butil::memory_order_relaxed);
+            }
         }
     };
 

--- a/src/butil/resource_pool_inl.h
+++ b/src/butil/resource_pool_inl.h
@@ -127,7 +127,8 @@ public:
             // We fetch_add nblock in add_block() before setting the entry,
             // thus address_resource() may sees the unset entry. Initialize
             // all entries to NULL makes such address_resource() return NULL.
-            memset(blocks, 0, sizeof(butil::atomic<Block*>) * RP_GROUP_NBLOCK);
+            for (size_t i = 0; i < RP_GROUP_NBLOCK; ++i)
+                blocks[i].store(NULL, butil::memory_order_relaxed);
         }
     };
 

--- a/src/butil/third_party/rapidjson/document.h
+++ b/src/butil/third_party/rapidjson/document.h
@@ -283,6 +283,9 @@ struct GenericStringRef {
     GenericStringRef(const CharType (&str)[N]) RAPIDJSON_NOEXCEPT
         : s(str), length(N-1) {}
 
+    GenericStringRef(const GenericStringRef &rhs)
+        : s(rhs.s), length(rhs.length) {}
+
     //! Explicitly create string reference from \c const character pointer
     /*!
         This constructor can be used to \b explicitly  create a reference to
@@ -1657,7 +1660,8 @@ private:
         flags_ = kArrayFlag;
         if (count) {
             data_.a.elements = (GenericValue*)allocator.Malloc(count * sizeof(GenericValue));
-            std::memcpy(data_.a.elements, values, count * sizeof(GenericValue));
+            for (SizeType i = 0; i < count; ++i)
+                data_.a.elements[i] = values[i];
         }
         else
             data_.a.elements = NULL;
@@ -1669,7 +1673,8 @@ private:
         flags_ = kObjectFlag;
         if (count) {
             data_.o.members = (Member*)allocator.Malloc(count * sizeof(Member));
-            std::memcpy(data_.o.members, members, count * sizeof(Member));
+            for (SizeType i = 0; i < count; ++i)
+                data_.o.members[i] = members[i];
         }
         else
             data_.o.members = NULL;

--- a/src/butil/time/time.h
+++ b/src/butil/time/time.h
@@ -71,6 +71,10 @@ class BUTIL_EXPORT TimeDelta {
   TimeDelta() : delta_(0) {
   }
 
+  TimeDelta(const TimeDelta& other) {
+    delta_ = other.delta_;
+  }
+
   // Converts units of time to TimeDeltas.
   static TimeDelta FromDays(int days);
   static TimeDelta FromHours(int hours);
@@ -267,6 +271,10 @@ class BUTIL_EXPORT Time {
 
   // Contains the NULL time. Use Time::Now() to get the current time.
   Time() : us_(0) {
+  }
+
+  Time(const Time& other) {
+    us_ = other.us_;
   }
 
   // Returns true if the time object has not been initialized.
@@ -606,6 +614,10 @@ class BUTIL_EXPORT TimeTicks {
 #endif
 
   TimeTicks() : ticks_(0) {
+  }
+
+  TimeTicks(const TimeTicks& other) {
+    ticks_ = other.ticks_;
   }
 
   // Platform-dependent tick count representing "right now."

--- a/src/bvar/detail/series.h
+++ b/src/bvar/detail/series.h
@@ -94,6 +94,21 @@ struct DivideOnAddition<Vector<T,N>, Op, typename butil::enable_if<
     }
 };
 
+template<typename T, bool B>
+struct ConstructArrayHelper {
+    template <size_t N>
+    static void fill(T (&array)[N]) {
+    }
+};
+
+template<typename T>
+struct ConstructArrayHelper<T, true> {
+    template <size_t N>
+    static void fill(T (&array)[N]) {
+        memset(array, 0, sizeof(array));
+    }
+};
+
 template <typename T, typename Op>
 class SeriesBase {
 public:
@@ -123,11 +138,8 @@ private:
     struct Data {
     public:
         Data() {
-            // is_pod does not work for gcc 3.4
-            if (butil::is_integral<T>::value ||
-                butil::is_floating_point<T>::value) {
-                memset(_array, 0, sizeof(_array));
-            }
+            ConstructArrayHelper<T, butil::is_integral<T>::value ||
+                butil::is_floating_point<T>::value>::fill(_array);
         }
         
         T& second(int index) { return _array[index]; }


### PR DESCRIPTION
- implicit copy constructor is missing while copy-assignment is implemented.

- atomic value should not be changed by memset or memcpy, because it may be implemented by mutex.